### PR TITLE
Update admin/index.php

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -96,7 +96,7 @@ while($dsondage = $sondage->FetchNextObject(false)) {
   $i++;
 }
 
-$sondage=$connect->Execute("select * from sondage");
+$sondage=$connect->Execute("select * from sondage where date_fin> DATE_SUB(now(), INTERVAL 3 MONTH)");");
 $nbsondages=$sondage->RecordCount();
 
 echo $nbsondages.' '. _("polls in the database at this time") .'<br><br>'."\n";


### PR DESCRIPTION
Modif pour ne faire apparaître dans la liste admin que les sondage actifs ou ayant expiré il y a moins de 3 mois.
(surtout utile pour les instances utilisant de tres nombreux sondages)
